### PR TITLE
[Breaking] Update dependencies and fix Broccoli deprecation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
   - 'stable'
-  - '4'
-  - '0.12'
+  - '8'
+  - '6'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
   - 'stable'
+  - '10'
   - '8'
-  - '6'

--- a/index.js
+++ b/index.js
@@ -6,20 +6,22 @@ var path = require('path');
 var chalk = require('chalk');
 var fs = require('fs');
 var findup = require('findup-sync');
-var mkdirp = require('mkdirp');
 var isPresent = require('is-present');
 
 CSSLinter.prototype = Object.create(Filter.prototype);
 CSSLinter.prototype.constructor = CSSLinter;
 
-function CSSLinter(inputTree, options) {
+function CSSLinter(inputNode, options) {
   if (!(this instanceof CSSLinter)) {
-    return new CSSLinter(inputTree, options);
+    return new CSSLinter(inputNode, options);
   }
 
   options = options || {};
 
-  this.inputTree = inputTree;
+  Filter.call(this, inputNode, {
+    annotation: options.annotation
+  });
+
   this.log = true;
 
   for (var key in options) {
@@ -31,26 +33,23 @@ function CSSLinter(inputTree, options) {
 
 CSSLinter.prototype.extensions = ['css'];
 
-CSSLinter.prototype.write = function (readTree, destDir) {
-  var self = this
+CSSLinter.prototype.build = function () {
+  var self = this;
   self._errors = [];
 
-  return readTree(this.inputTree).then(function (srcDir) {
-    if (!self.csslintrc) {
-      var csslintrcPath = self.csslintrcPath || path.join(srcDir, self.csslintrcRoot || '');
-      self.csslintrc = self.getConfig(csslintrcPath);
-    }
+  var srcDir = this.inputPaths[0];
+  var csslintrcPath = path.join(srcDir, this.csslintrcRoot || '');
+  this.csslintrc = this.getConfig(csslintrcPath);
 
-    return Filter.prototype.write.call(self, readTree, destDir)
-  })
-  .finally(function() {
-    if (self._errors.length > 0) {
-      var label = ' Files with CSSLint Errors';
-      console.log('\n' + self._errors.join('\n'));
-      console.log(chalk.yellow('===== ' + self._errors.length + label + '\n'));
-    }
-  });
-}
+  return Filter.prototype.build.apply(this, arguments)
+    .finally(function() {
+      if (self._errors.length > 0) {
+        var label = ' Files with CSSLint Errors';
+        console.log('\n' + self._errors.join('\n'));
+        console.log(chalk.yellow('===== ' + self._errors.length + label + '\n'));
+      }
+    });
+};
 
 CSSLinter.prototype.processString = function (content, relativePath) {
   var filesToExclude =  this.csslintrc['exclude-list'];
@@ -85,7 +84,7 @@ CSSLinter.prototype.processMessages = function (file, messages) {
   }).join('\n');
 
   return messageStr + '\n' + len + ' error' + ((len === 1) ? '' : 's');
-}
+};
 
 CSSLinter.prototype.logError = function(message, color) {
   color = color || 'red';
@@ -118,11 +117,13 @@ CSSLinter.prototype.getConfig = function(rootPath) {
   });
 
   for (var rule in lintOptions) {
-    if (!lintOptions[rule]) {
-      delete ruleset[rule];
-    }
-    else {
-      ruleset[rule] = lintOptions[rule];
+    if (lintOptions.hasOwnProperty(rule)) {
+      if (!lintOptions[rule]) {
+        delete ruleset[rule];
+      }
+      else {
+        ruleset[rule] = lintOptions[rule];
+      }
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var csslint = require('csslint').CSSLint;
-var Filter = require('broccoli-filter');
+var Filter = require('broccoli-persistent-filter');
 var path = require('path');
 var chalk = require('chalk');
 var fs = require('fs');
@@ -17,9 +17,13 @@ function CSSLinter(inputNode, options) {
   }
 
   options = options || {};
+  if (!options.hasOwnProperty('persist')) {
+    options.persist = true;
+  }
 
   Filter.call(this, inputNode, {
-    annotation: options.annotation
+    annotation: options.annotation,
+    persist: options.persist
   });
 
   this.log = true;
@@ -29,6 +33,10 @@ function CSSLinter(inputNode, options) {
       this[key] = options[key]
     }
   }
+};
+
+CSSLinter.prototype.baseDir = function() {
+  return __dirname;
 };
 
 CSSLinter.prototype.extensions = ['css'];

--- a/index.js
+++ b/index.js
@@ -45,8 +45,7 @@ CSSLinter.prototype.build = function () {
   var self = this;
   self._errors = [];
 
-  var srcDir = this.inputPaths[0];
-  var csslintrcPath = path.join(srcDir, this.csslintrcRoot || '');
+  var csslintrcPath = this.csslintrcRoot || process.cwd();
   this.csslintrc = this.getConfig(csslintrcPath);
 
   return Filter.prototype.build.apply(this, arguments)

--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@
 
 var csslint = require('csslint').CSSLint;
 var Filter = require('broccoli-persistent-filter');
-var path = require('path');
 var chalk = require('chalk');
 var fs = require('fs');
 var findup = require('findup-sync');

--- a/package.json
+++ b/package.json
@@ -30,13 +30,13 @@
   "devDependencies": {
     "broccoli": "^2.0.1",
     "expect.js": "^0.3.1",
-    "mocha": "^5.2.0"
+    "mocha": "^6.1.2"
   },
   "dependencies": {
     "broccoli-persistent-filter": "^2.1.1",
     "chalk": "^2.4.1",
     "csslint": "^1.0.5",
-    "findup-sync": "^2.0.0",
+    "findup-sync": "^3.0.0",
     "is-present": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "mocha": "^5.2.0"
   },
   "dependencies": {
-    "broccoli-filter": "^1.3.0",
+    "broccoli-persistent-filter": "^2.1.1",
     "chalk": "^2.4.1",
     "csslint": "^1.0.5",
     "findup-sync": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -28,13 +28,13 @@
   },
   "homepage": "https://github.com/johnotander/broccoli-csslint",
   "devDependencies": {
-    "broccoli": "^2.0.1",
+    "broccoli": "^2.3.0",
     "expect.js": "^0.3.1",
-    "mocha": "^6.1.2"
+    "mocha": "^6.1.4"
   },
   "dependencies": {
-    "broccoli-persistent-filter": "^2.1.1",
-    "chalk": "^2.4.1",
+    "broccoli-persistent-filter": "^2.2.2",
+    "chalk": "^2.4.2",
     "csslint": "^1.0.5",
     "findup-sync": "^3.0.0",
     "is-present": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -28,16 +28,15 @@
   },
   "homepage": "https://github.com/johnotander/broccoli-csslint",
   "devDependencies": {
-    "broccoli": "^0.16.2",
+    "broccoli": "^2.0.1",
     "expect.js": "^0.3.1",
-    "mocha": "^2.2.4"
+    "mocha": "^5.2.0"
   },
   "dependencies": {
-    "broccoli-filter": "^0.1.14",
-    "chalk": "^1.0.0",
+    "broccoli-filter": "^1.3.0",
+    "chalk": "^2.4.1",
     "csslint": "^1.0.5",
-    "findup-sync": "^0.2.1",
-    "is-present": "0.0.1",
-    "mkdirp": "^0.5.0"
+    "findup-sync": "^2.0.0",
+    "is-present": "^1.0.0"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var cssLint = require('..');
+var CSSLinter = require('..');
 var expect = require('expect.js');
 var fs = require('fs');
 var broccoli = require('broccoli');
@@ -33,7 +33,7 @@ describe('broccoli-csslint', function() {
   it('can handle an empty file', function() {
     var sourcePath = 'test/fixtures/empty';
     chdir(sourcePath);
-    var tree = cssLint('.', {
+    var tree = new CSSLinter('.', {
       logError: function(message) { loggerOutput.push(message) }
     });
 
@@ -47,7 +47,7 @@ describe('broccoli-csslint', function() {
     var sourcePath = 'test/fixtures/valid-css-file';
     chdir(sourcePath);
 
-    var tree = cssLint('.', {
+    var tree = new CSSLinter('.', {
       logError: function(message) { loggerOutput.push(message) }
     });
 
@@ -61,7 +61,7 @@ describe('broccoli-csslint', function() {
     var sourcePath = 'test/fixtures/css-file-that-uses-important';
     chdir(sourcePath);
 
-    var tree = cssLint('.', {
+    var tree = new CSSLinter('.', {
       logError: function(message) { loggerOutput.push(message) }
     });
 
@@ -76,7 +76,7 @@ describe('broccoli-csslint', function() {
     var sourcePath = 'test/fixtures/css-file-with-multiple-errors';
     chdir(sourcePath);
 
-    var tree = cssLint('.', {
+    var tree = new CSSLinter('.', {
       logError: function(message) { loggerOutput.push(message) }
     });
 
@@ -92,7 +92,7 @@ describe('broccoli-csslint', function() {
     var sourcePath = 'test/fixtures/css-file-that-uses-important';
     chdir(sourcePath);
 
-    var tree = cssLint('.', {
+    var tree = new CSSLinter('.', {
       csslintrcRoot: '..',
       logError: function(message) { loggerOutput.push(message) }
     });
@@ -107,7 +107,7 @@ it('excludes files that are not meant to be a part of builds', function() {
     var sourcePath = 'test/fixtures/css-files-that-need-to-be-ignored';
     chdir(sourcePath);
 
-    var tree = cssLint('.', {
+    var tree = new CSSLinter('.', {
       logError: function(message) { loggerOutput.push(message) }
     });
 


### PR DESCRIPTION
With Ember CLI 3.4 upgrade we got bunch of deprecation messages coming from this plugin:
```
[API] Warning: The .read and .rebuild APIs will stop working in the next Broccoli version
[API] Warning: Use broccoli-plugin instead: https://github.com/broccolijs/broccoli-plugin
[API] Warning: Plugin uses .read/.rebuild API: CSSLinter
```

This attempts to comply with broccoli-filter 1.x API

Addresses #5